### PR TITLE
Add tip for reverting local master back to origin

### DIFF
--- a/_posts/2014-10-27-sanitizing-local-master-branch.markdown
+++ b/_posts/2014-10-27-sanitizing-local-master-branch.markdown
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "Reverting local master to the origin master"
+---
+
+## Reverting local master to the origin master
+
+
+```bash
+
+git checkout origin/master -B master
+```


### PR DESCRIPTION
For all those times we accidentally add in commits we don't want into the local master, this is a good way to change it back to the origin. Credit to @stefanor.

By the looks of it, this probably works for any branch.
